### PR TITLE
Fix null headers array with non-nil default

### DIFF
--- a/firetail/record.go
+++ b/firetail/record.go
@@ -46,6 +46,9 @@ func (r *Record) getLogEntryRequest() (*LogEntryRequest, error) {
 			URI:          "https://" + apiGatewayV1Request.RequestContext.DomainName + apiGatewayV1Request.RequestContext.Path,
 			Resource:     apiGatewayV1Request.Resource,
 		}
+		if logEntryRequest.Headers == nil {
+			logEntryRequest.Headers = map[string][]string{}
+		}
 		for header, value := range apiGatewayV1Request.Headers {
 			_, hasValues := logEntryRequest.Headers[header]
 			if hasValues {


### PR DESCRIPTION
 - Makes the `request.headers` array in the NDJSON sent to the Firetail logging API `[]` instead of `null`.
 - Potentially avoids a nil pointer dereference where the `APIGatewayProxyRequest`'s `MultiValueHeaders` is `nil` but its `Headers` field is not.