### PR TITLE
Fire 747/lenient payload parsing

### DIFF
--- a/logsapi/client.go
+++ b/logsapi/client.go
@@ -53,7 +53,6 @@ func (c *Client) Start(ctx context.Context) error {
 	if err != http.ErrServerClosed {
 		err = errors.WithMessage(err, "Log server closed unexpectedly")
 		c.errCallback(err)
-		c.Shutdown(ctx)
 	} else if err != nil {
 		c.errCallback(err)
 	}

--- a/logsapi/extract_firetail_records.go
+++ b/logsapi/extract_firetail_records.go
@@ -51,11 +51,16 @@ func extractFiretailRecords(requestBody []byte) ([]firetail.Record, error) {
 func decodeFiretailRecord(record string) (*firetail.Record, error) {
 	recordParts := strings.Split(record, ":")
 
-	if len(recordParts) != 3 {
+	if len(recordParts) < 3 {
 		return nil, fmt.Errorf("record had %d parts when split by ':'", len(recordParts))
 	}
 
-	if recordParts[0] != "firetail" {
+	// If there's more than 3 parts, we take the last three; we're assuming the last part of the log is the payload we want.
+	if len(recordParts) > 3 {
+		recordParts = recordParts[len(recordParts)-3:]
+	}
+
+	if !strings.HasSuffix(recordParts[0], "firetail") {
 		return nil, fmt.Errorf("record did not have firetail prefix")
 	}
 

--- a/logsapi/extract_firetail_records_test.go
+++ b/logsapi/extract_firetail_records_test.go
@@ -56,7 +56,7 @@ func TestDecodeFiretailRecordWithExtraPart(t *testing.T) {
 	assert.Nil(t, decodedRecord)
 	require.NotNil(t, err)
 
-	assert.Equal(t, "record had 4 parts when split by ':'", err.Error())
+	assert.Equal(t, "record did not have firetail prefix", err.Error())
 }
 
 func TestDecodeFiretailRecordWithInvalidPrefix(t *testing.T) {

--- a/logsapi/extract_firetail_records_test.go
+++ b/logsapi/extract_firetail_records_test.go
@@ -40,7 +40,7 @@ func TestDecodeFiretailRecordWithMissingPart(t *testing.T) {
 	assert.Equal(t, "record had 2 parts when split by ':'", err.Error())
 }
 
-func TestDecodeFiretailRecordWithExtraPart(t *testing.T) {
+func TestDecodeFiretailRecordWithExtraPartSuffixed(t *testing.T) {
 	testRecord := firetail.Record{
 		Response: firetail.RecordResponse{
 			StatusCode: 200,
@@ -57,6 +57,24 @@ func TestDecodeFiretailRecordWithExtraPart(t *testing.T) {
 	require.NotNil(t, err)
 
 	assert.Equal(t, "record did not have firetail prefix", err.Error())
+}
+
+func TestDecodeFiretailRecordWithExtraPartPrefixed(t *testing.T) {
+	testRecord := firetail.Record{
+		Response: firetail.RecordResponse{
+			StatusCode: 200,
+			Body:       "Test Body",
+		},
+	}
+	testPayloadBytes, err := json.Marshal(testRecord)
+	require.Nil(t, err)
+
+	encodedRecord := "extra:firetail:log-ext:" + base64.StdEncoding.EncodeToString(testPayloadBytes) + ""
+
+	decodedRecord, err := decodeFiretailRecord(encodedRecord)
+	require.Nil(t, err)
+
+	assert.Equal(t, testRecord.Response, *&decodedRecord.Response)
 }
 
 func TestDecodeFiretailRecordWithInvalidPrefix(t *testing.T) {

--- a/logsapi/extract_firetail_records_test.go
+++ b/logsapi/extract_firetail_records_test.go
@@ -78,6 +78,24 @@ func TestDecodeFiretailRecordWithInvalidPrefix(t *testing.T) {
 	assert.Equal(t, "record did not have firetail prefix", err.Error())
 }
 
+func TestDecodeFiretailRecordWithTimestampPrefix(t *testing.T) {
+	testRecord := firetail.Record{
+		Response: firetail.RecordResponse{
+			StatusCode: 200,
+			Body:       "Test Body",
+		},
+	}
+	testPayloadBytes, err := json.Marshal(testRecord)
+	require.Nil(t, err)
+
+	encodedRecord := "2023-02-09T14:12:59.574Z    7b9025e7-228f-4f39-ab16-1cadba2bb3f6    INFO    firetail:log-ext:" + base64.StdEncoding.EncodeToString(testPayloadBytes)
+
+	decodedRecord, err := decodeFiretailRecord(encodedRecord)
+	require.Nil(t, err)
+
+	assert.Equal(t, testRecord.Response, *&decodedRecord.Response)
+}
+
 func TestDecodeFiretailRecordWithInvalidToken(t *testing.T) {
 	testRecord := firetail.Record{
 		Response: firetail.RecordResponse{

--- a/main.go
+++ b/main.go
@@ -55,5 +55,5 @@ func main() {
 
 	// Sleep for 500ms to allow any final logs to be sent to the extension by the Lambda Logs API
 	log.Printf("Sleeping for 500ms to allow final logs to be processed...")
-	time.Sleep(500)
+	time.Sleep(500 * time.Millisecond)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -6,6 +6,9 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMain(t *testing.T) {
@@ -31,4 +34,20 @@ func TestMainDebug(t *testing.T) {
 	t.Setenv("FIRETAIL_EXTENSION_DEBUG", "true")
 
 	main()
+}
+
+func TestMainReturnsInNoLessThan500Milliseconds(t *testing.T) {
+	http.DefaultServeMux = new(http.ServeMux)
+	mockExtensionsApi := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `{"eventType": "SHUTDOWN"}`)
+	}))
+	defer mockExtensionsApi.Close()
+
+	t.Setenv("AWS_LAMBDA_RUNTIME_API", strings.Join(strings.Split(mockExtensionsApi.URL, ":")[1:], ":")[2:])
+
+	startTime := time.Now()
+
+	main()
+
+	assert.Greater(t, time.Since(startTime), 500*time.Millisecond)
 }


### PR DESCRIPTION
The firetail-js-lambda wrapper results in log payloads that are prefixed as follows:

```
2023-02-09T14:12:59.574Z    8s72nc8a-92jd-ci29-2jd9-8dj29d74nsr    INFO 
```

This PR updates the extension to parse payloads with any prefix & adds appropriate tests.